### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
 

--- a/.github/workflows/codeql-analyze.yml
+++ b/.github/workflows/codeql-analyze.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -67,14 +67,14 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
         if: ${{ inputs.run-fossa == 'true' }}
-        uses: fossas/fossa-action@v1.3.1
+        uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{ secrets.fossa-api-key }}
 

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -72,10 +72,10 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -120,14 +120,14 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
         if: ${{ inputs.run-fossa == 'true' }}
-        uses: fossas/fossa-action@v1.3.1
+        uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{ secrets.fossa-api-key }}
 

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Git
         run: |
@@ -48,7 +48,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -33,10 +33,10 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -57,13 +57,13 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.1
+        uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{ secrets.fossa-api-key }}
 

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -64,10 +64,10 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -111,13 +111,13 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.1
+        uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{ secrets.fossa-api-key }}
 

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Git
         run: |
@@ -61,7 +61,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -33,10 +33,10 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -51,12 +51,12 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.1
+        uses: fossas/fossa-action@v1.3.3
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Validate Gradle Wrapper
         if: ${{ inputs.run-gradle-validation == true }}
-        uses: gradle/wrapper-validation-action@v2.0.0
+        uses: gradle/wrapper-validation-action@v2.1.1
 
       - name: Setup Git
         run: |
@@ -55,7 +55,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.1.0](https://github.com/actions/setup-java/releases/tag/v4.1.0)** on 2024-02-28T05:25:25Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.1.0](https://github.com/codecov/codecov-action/releases/tag/v4.1.0)** on 2024-02-26T20:16:40Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[fossas/fossa-action](https://github.com/fossas/fossa-action)** published a new release **[v1.3.3](https://github.com/fossas/fossa-action/releases/tag/v1.3.3)** on 2024-02-15T21:26:25Z
* **[gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action)** published a new release **[v2.1.1](https://github.com/gradle/wrapper-validation-action/releases/tag/v2.1.1)** on 2024-02-10T17:02:42Z
