### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analyze.yml
+++ b/.github/workflows/codeql-analyze.yml
@@ -45,14 +45,14 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Initialize
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@codeql-bundle-20230524
         with:
           languages: ${{ matrix.language }}
 
       - name: Auto Build
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@codeql-bundle-20230524
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@codeql-bundle-20230524
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
