### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analyze.yml
+++ b/.github/workflows/codeql-analyze.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -43,13 +43,13 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -71,6 +71,6 @@ jobs:
 
       - name: FOSSA
         if: ${{ inputs.run-fossa == 'true' }}
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@v1.4.0
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -98,7 +98,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -124,6 +124,6 @@ jobs:
 
       - name: FOSSA
         if: ${{ inputs.run-fossa == 'true' }}
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@v1.4.0
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v4.1.7
         
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Gradle Dependencies Submission
-        uses: gradle/actions/dependency-submission@v3.5.0
+        uses: gradle/actions/dependency-submission@v4.0.0

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -52,13 +52,13 @@ jobs:
           GIT_USER: ${{ inputs.git-user }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -60,6 +60,6 @@ jobs:
           token: ${{ secrets.codecov-token }}
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@v1.4.0
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -90,7 +90,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -114,6 +114,6 @@ jobs:
           token: ${{ secrets.codecov-token }}
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@v1.4.0
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -67,13 +67,13 @@ jobs:
           GIT_USER: ${{ inputs.git-user }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v4.1.7
         
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -60,6 +60,6 @@ jobs:
           token: ${{ secrets.codecov-token }}
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@v1.4.0
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -58,13 +58,13 @@ jobs:
           GIT_USER: ${{ inputs.git-user }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.2.2
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3.5.0
+        uses: gradle/actions/setup-gradle@v4.0.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[fossas/fossa-action](https://github.com/fossas/fossa-action)** published a new release **[v1.4.0](https://github.com/fossas/fossa-action/releases/tag/v1.4.0)** on 2024-08-06T21:28:33Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.0.0](https://github.com/gradle/actions/releases/tag/v4.0.0)** on 2024-08-07T16:20:16Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.2](https://github.com/actions/setup-java/releases/tag/v4.2.2)** on 2024-08-05T14:04:36Z
