### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup Node
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: 20
 

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -52,7 +52,7 @@ jobs:
           LABEL: ${{ github.event.label.name }}
 
       - name: Azure Login
-        uses: azure/login@v2.1.1
+        uses: azure/login@v2.2.0
         with:
           creds: ${{ secrets.azure-app-credentials }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.4](https://github.com/actions/setup-node/releases/tag/v4.0.4)** on 2024-09-19T14:07:35Z
* **[azure/login](https://github.com/azure/login)** published a new release **[v2.2.0](https://github.com/Azure/login/releases/tag/v2.2.0)** on 2024-09-18T07:42:19Z
