### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -42,7 +42,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v5.0.7
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -91,7 +91,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v5.0.7
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -29,4 +29,4 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Gradle Dependencies Submission
-        uses: gradle/actions/dependency-submission@v4.2.0
+        uses: gradle/actions/dependency-submission@v4.2.1

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -58,7 +58,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -50,7 +50,7 @@ jobs:
           ktlint-version: 1.2.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v5.0.7
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -87,7 +87,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -104,7 +104,7 @@ jobs:
           ktlint-version: 1.2.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v5.0.7
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -73,7 +73,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 
@@ -50,7 +50,7 @@ jobs:
           ktlint-version: 1.2.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.0.2
+        uses: codecov/codecov-action@v5.0.7
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -64,7 +64,7 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.2.0
+        uses: gradle/actions/setup-gradle@v4.2.1
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.0.7](https://github.com/codecov/codecov-action/releases/tag/v5.0.7)** on 2024-11-21T12:28:45Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v4.2.1](https://github.com/gradle/actions/releases/tag/v4.2.1)** on 2024-11-18T17:46:18Z
