### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: 20
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
