### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-codeql-analyze.yml
+++ b/.github/workflows/python-codeql-analyze.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
@@ -51,14 +51,14 @@ jobs:
         continue-on-error: false
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.4.0
+        uses: codecov/codecov-action@v5.4.2
         with:
           files: ./coverage.xml
           verbose: true
           token: ${{ secrets.codecov-token }}
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: coverage
           path: ./coverage.xml

--- a/.github/workflows/python-py-pi-release.yml
+++ b/.github/workflows/python-py-pi-release.yml
@@ -53,7 +53,7 @@ jobs:
           GIT_USER: ${{ inputs.git-user }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
@@ -86,13 +86,13 @@ jobs:
         run: python -m build
 
       - name: Upload Distribution Packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Download Distribution Packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
@@ -113,7 +113,7 @@ jobs:
           --repo "$GITHUB_REPOSITORY"
 
       - name: Publish Distribution Package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.py-pi-token }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)** on 2025-04-24T02:50:16Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.12.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4)** on 2025-01-24T03:29:15Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.3.0](https://github.com/actions/download-artifact/releases/tag/v4.3.0)** on 2025-04-24T16:28:16Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.2](https://github.com/codecov/codecov-action/releases/tag/v5.4.2)** on 2025-04-14T20:02:26Z
