### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-py-pi-release.yml
+++ b/.github/workflows/python-py-pi-release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Set Release Version and Tag
         id: set_release_and_tag
-        uses: callowayproject/bump-my-version@1.1.4
+        uses: callowayproject/bump-my-version@1.2.0
         env:
           BUMPVERSION_TAG: true
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[callowayproject/bump-my-version](https://github.com/callowayproject/bump-my-version)** published a new release **[1.2.0](https://github.com/callowayproject/bump-my-version/releases/tag/1.2.0)** on 2025-06-07T14:35:59Z
