### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -100,7 +100,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/python-code-coverage.yml
+++ b/.github/workflows/python-code-coverage.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
@@ -46,7 +46,7 @@ jobs:
           python -m pytest --cov-config=pyproject.toml
 
       - name: Coverage
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-codeql-analyze.yml
+++ b/.github/workflows/python-codeql-analyze.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-py-pi-release.yml
+++ b/.github/workflows/python-py-pi-release.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.workflow-token }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.5.1](https://github.com/codecov/codecov-action/releases/tag/v5.5.1)** on 2025-09-04T14:36:56Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)** on 2025-09-04T02:52:29Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v6.0.0](https://github.com/actions/setup-python/releases/tag/v6.0.0)** on 2025-09-04T03:14:37Z
