### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -91,7 +91,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-cli-build.yml
+++ b/.github/workflows/gradle-cli-build.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -29,4 +29,4 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Gradle Dependencies Submission
-        uses: gradle/actions/dependency-submission@v6.0.1
+        uses: gradle/actions/dependency-submission@v6.1.0

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -66,7 +66,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -91,7 +91,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -81,7 +81,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -72,7 +72,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -92,7 +92,7 @@ jobs:
           FLYWAY_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.0.1
+        uses: gradle/actions/setup-gradle@v6.1.0
         with:
           validate-wrappers: ${{ inputs.run-gradle-validation }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v6.1.0](https://github.com/gradle/actions/releases/tag/v6.1.0)** on 2026-04-03T15:07:29Z
