### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-release-build.yml
+++ b/.github/workflows/python-release-build.yml
@@ -68,7 +68,7 @@ jobs:
         run: python -m build
 
       - name: Upload Distribution Packages
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -43,7 +43,7 @@ jobs:
           git commit -m "Update next Python project version from $RELEASE_VERSION to $NEXT_DEV_VERSION"
 
       - name: Push Next Project Version Change
-        uses: ad-m/github-push-action@v1.0.0
+        uses: ad-m/github-push-action@v1.1.0
         with:
           github_token: ${{ secrets.workflow-token }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v1.1.0](https://github.com/ad-m/github-push-action/releases/tag/v1.1.0)** on 2026-04-10T05:20:38Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1)** on 2026-04-10T17:31:14Z
