### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
 

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1
 

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -103,7 +103,7 @@ jobs:
           SPRING_DATASOURCE_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1
 

--- a/.github/workflows/gradle-cli-build.yml
+++ b/.github/workflows/gradle-cli-build.yml
@@ -41,6 +41,6 @@ jobs:
         run: ./gradlew clean build
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1
 

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -103,7 +103,7 @@ jobs:
           SPRING_DATASOURCE_PASSWORD: ${{ secrets.postgres-build-db-svc-password }}
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1
 

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Codestyle
-        uses: musichin/ktlint-check@v4.0.2
+        uses: musichin/ktlint-check@v4.0.3
         with:
           ktlint-version: 1.2.1
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v6.4.0](https://github.com/actions/setup-node/releases/tag/v6.4.0)** on 2026-04-20T02:57:28Z
* **[musichin/ktlint-check](https://github.com/musichin/ktlint-check)** published a new release **[v4.0.3](https://github.com/musichin/ktlint-check/releases/tag/v4.0.3)** on 2026-04-19T06:58:46Z
