### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -100,7 +100,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/python-code-coverage.yml
+++ b/.github/workflows/python-code-coverage.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pytest --cov-config=pyproject.toml
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v6.0.1
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -43,7 +43,7 @@ jobs:
           git commit -m "Update next Python project version from $RELEASE_VERSION to $NEXT_DEV_VERSION"
 
       - name: Push Next Project Version Change
-        uses: ad-m/github-push-action@v1.1.0
+        uses: ad-m/github-push-action@v1.2.0
         with:
           github_token: ${{ secrets.workflow-token }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v6.0.1](https://github.com/codecov/codecov-action/releases/tag/v6.0.1)** on 2026-05-18T18:36:53Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v1.2.0](https://github.com/ad-m/github-push-action/releases/tag/v1.2.0)** on 2026-05-23T10:16:43Z
