### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Node
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, format('deploy {0}', inputs.env)) && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Download Release Artifact
         run: |

--- a/.github/workflows/gradle-cli-build.yml
+++ b/.github/workflows/gradle-cli-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         
       - name: Setup Java
         uses: actions/setup-java@v5.2.0

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -109,7 +109,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -59,7 +59,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -55,7 +55,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ inputs.run-code-coverage == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/java-kotlin-codeql-analyze.yml
+++ b/.github/workflows/java-kotlin-codeql-analyze.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Java
         uses: actions/setup-java@v5.2.0

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -100,7 +100,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/python-code-coverage.yml
+++ b/.github/workflows/python-code-coverage.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ inputs.run-code-coverage == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Python
         uses: actions/setup-python@v6.2.0
@@ -46,7 +46,7 @@ jobs:
           python -m pytest --cov-config=pyproject.toml
 
       - name: Coverage
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-codeql-analyze.yml
+++ b/.github/workflows/python-codeql-analyze.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Python
         uses: actions/setup-python@v6.2.0

--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Python
         uses: actions/setup-python@v6.2.0
@@ -56,7 +56,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-code-coverage == true }}
-        uses: codecov/codecov-action@v6.0.1
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
           verbose: true

--- a/.github/workflows/python-release-build.yml
+++ b/.github/workflows/python-release-build.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/workflow-clear-packages.yml
+++ b/.github/workflows/workflow-clear-packages.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Set Package Name
         run: |

--- a/.github/workflows/workflow-update-actions.yml
+++ b/.github/workflows/workflow-update-actions.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           token: ${{ secrets.workflow-token }}
 

--- a/.github/workflows/workflow-update-license-copyright.yml
+++ b/.github/workflows/workflow-update-license-copyright.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           token: ${{ secrets.workflow-token }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.3](https://github.com/actions/checkout/releases/tag/v6.0.3)** on 2026-06-02T14:35:13Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)** on 2026-06-07T01:47:01Z
