### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node
         uses: actions/setup-node@v7.0.0

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, format('deploy {0}', inputs.env)) && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Download Release Artifact
         run: |

--- a/.github/workflows/gradle-cli-build.yml
+++ b/.github/workflows/gradle-cli-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -59,7 +59,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ inputs.run-code-coverage == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/java-kotlin-codeql-analyze.yml
+++ b/.github/workflows/java-kotlin-codeql-analyze.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         
       - name: Setup Java
         uses: actions/setup-java@v5.6.0

--- a/.github/workflows/python-code-coverage.yml
+++ b/.github/workflows/python-code-coverage.yml
@@ -24,10 +24,10 @@ jobs:
     if: ${{ inputs.run-code-coverage == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/python-codeql-analyze.yml
+++ b/.github/workflows/python-codeql-analyze.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/python-package-build.yml
+++ b/.github/workflows/python-package-build.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/python-release-build.yml
+++ b/.github/workflows/python-release-build.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'release') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
           token: ${{ secrets.workflow-token }}
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.workflow-token }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'

--- a/.github/workflows/workflow-clear-packages.yml
+++ b/.github/workflows/workflow-clear-packages.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set Package Name
         run: |

--- a/.github/workflows/workflow-update-actions.yml
+++ b/.github/workflows/workflow-update-actions.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           token: ${{ secrets.workflow-token }}
 

--- a/.github/workflows/workflow-update-license-copyright.yml
+++ b/.github/workflows/workflow-update-license-copyright.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           token: ${{ secrets.workflow-token }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v7.0.0](https://github.com/actions/setup-python/releases/tag/v7.0.0)** on 2026-07-20T03:15:01Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)** on 2026-07-20T15:10:05Z
