### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-cli-build.yml
+++ b/.github/workflows/gradle-cli-build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-dependencies-submit.yml
+++ b/.github/workflows/gradle-dependencies-submit.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -60,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.workflow-token }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-maven-central-release.yml
+++ b/.github/workflows/gradle-maven-central-release.yml
@@ -75,7 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.workflow-token }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.workflow-token }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/java-kotlin-code-coverage.yml
+++ b/.github/workflows/java-kotlin-code-coverage.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/java-kotlin-codeql-analyze.yml
+++ b/.github/workflows/java-kotlin-codeql-analyze.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/java-kotlin-postgres-code-coverage.yml
+++ b/.github/workflows/java-kotlin-postgres-code-coverage.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         
       - name: Setup Java
-        uses: actions/setup-java@v5.6.0
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Set Release Version and Tag
         id: set_release_and_tag
-        uses: callowayproject/bump-my-version@1.4.0
+        uses: callowayproject/bump-my-version@1.5.0
         env:
           BUMPVERSION_TAG: true
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.7.0](https://github.com/actions/setup-java/releases/tag/v5.7.0)** on 2026-07-31T19:41:06Z
* **[callowayproject/bump-my-version](https://github.com/callowayproject/bump-my-version)** published a new release **[1.5.0](https://github.com/callowayproject/bump-my-version/releases/tag/1.5.0)** on 2026-07-27T18:17:14Z
